### PR TITLE
installation: fix invenio_upgrader dependency

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -27,3 +27,5 @@
 #
 #     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
+
+-e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ history = open('CHANGES.rst').read()
 requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
+    'invenio-upgrader>=0.1.0',
     # FIXME 'Invenio>=2.1',
 ]
 


### PR DESCRIPTION
* FIX Adds missing `invenio_upgrader` dependency following its
  separation into standalone package.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>