### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/invenio_pidstore/models.py
+++ b/invenio_pidstore/models.py
@@ -56,7 +56,7 @@ from datetime import datetime
 
 from sqlalchemy.exc import SQLAlchemyError
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.ext.sqlalchemy import db
 from invenio.utils.text import to_unicode
 

--- a/invenio_pidstore/provider.py
+++ b/invenio_pidstore/provider.py
@@ -21,7 +21,7 @@
 
 from werkzeug.utils import import_string
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.utils.datastructures import LazyDict
 
 

--- a/invenio_pidstore/providers/datacite.py
+++ b/invenio_pidstore/providers/datacite.py
@@ -25,7 +25,7 @@ from datacite import DataCiteMDSClient
 from datacite.errors import DataCiteError, DataCiteGoneError, \
     DataCiteNoContentError, DataCiteNotFoundError, HttpError
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 
 from ..provider import PidProvider
 

--- a/invenio_pidstore/providers/local_doi.py
+++ b/invenio_pidstore/providers/local_doi.py
@@ -19,7 +19,7 @@
 
 """Define provider for locally unmanaged DOIs."""
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 
 from ..provider import LocalPidProvider, PidProvider
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -28,4 +28,5 @@
 #     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
 
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
 -e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ history = open('CHANGES.rst').read()
 requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
+    'invenio-base>=0.1.0',
     'invenio-upgrader>=0.1.0',
     # FIXME 'Invenio>=2.1',
 ]


### PR DESCRIPTION
* FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>