### PR TITLE
resolver: pid to internal object resolving

### DIFF
--- a/invenio_pidstore/config.py
+++ b/invenio_pidstore/config.py
@@ -1,35 +1,40 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2015 CERN.
 #
-# Invenio is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# Invenio is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Invenio; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 """Pidstore config."""
 
-from __future__ import unicode_literals
+from __future__ import absolute_import, print_function
 
 import pkg_resources
 
 PIDSTORE_PROVIDERS = [
+    'invenio_pidstore.providers.recordid:RecordID',
     'invenio_pidstore.providers.local_doi:LocalDOI',
 ]
 
 EXTRA_PIDSTORE_PROVIDERS = [
     ('datacite', 'invenio_pidstore.providers.datacite:DataCite', ),
-    ('invenio_records', 'invenio_records.providers.recid:RecordID', ),
 ]
 
 for dependency, provider in EXTRA_PIDSTORE_PROVIDERS:
@@ -37,8 +42,8 @@ for dependency, provider in EXTRA_PIDSTORE_PROVIDERS:
         pkg_resources.get_distribution(dependency)
     except pkg_resources.DistributionNotFound:
         import warnings
-        warnings.warn("Dependency {0} is required to provider {1}".format(
-            dependency, provider.split(":")[-1]))
+        warnings.warn("Dependency {0} is required for provider {1}".format(
+            dependency, provider.split(":")[-1]), ImportWarning)
     else:
         PIDSTORE_PROVIDERS.append(provider)
 

--- a/invenio_pidstore/errors.py
+++ b/invenio_pidstore/errors.py
@@ -22,20 +22,34 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""Define provider for locally unmanaged DOIs."""
-
-from flask import current_app
-
-from ..provider import LocalPidProvider
+"""Errors for persistent identifiers."""
 
 
-class LocalDOI(LocalPidProvider):
-    """Provider for locally unmanaged DOIs."""
+class ResolverError(Exception):
+    """Base class for resolver errors."""
 
-    pid_type = 'doi'
+    def __init__(self, pid_type, pid_value, *args, **kwargs):
+        """Initialize exception."""
+        self.pid_value = pid_type
+        self.pid_value = pid_value
+        super(ResolverError, self).__init__(*args, **kwargs)
 
-    @classmethod
-    def is_provider_for_pid(cls, pid_str):
-        """Check if DOI is not the local datacite managed one."""
-        return not pid_str.startswith("{0}/".format(
-            current_app.config['PIDSTORE_DATACITE_DOI_PREFIX']))
+
+class PIDDoesNotExistsError(ResolverError):
+    """Persistent identifier does not exists."""
+
+
+class PIDDeletedError(ResolverError):
+    """Persistent identifier is deleted."""
+
+
+class PIDMissingObjectError(ResolverError):
+    """Persistent identifier has no object."""
+
+
+class PIDUnregistered(ResolverError):
+    """Persistent identifier is not registered."""
+
+
+class PIDMergedError(ResolverError):
+    """Persistent identifier is merged into another."""

--- a/invenio_pidstore/models.py
+++ b/invenio_pidstore/models.py
@@ -1,21 +1,26 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2015 CERN.
 #
-# Invenio is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# Invenio is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Invenio; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 """PersistentIdentifier store and registration.
 
@@ -51,6 +56,8 @@ Usage example for registering new identifiers::
     # Delete the DOI (you shouldn't be doing this ;-)
     pid.delete()
 """
+
+from __future__ import absolute_import, print_function
 
 from datetime import datetime
 

--- a/invenio_pidstore/provider.py
+++ b/invenio_pidstore/provider.py
@@ -1,23 +1,30 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2015 CERN.
 #
-# Invenio is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# Invenio is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Invenio; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 """Define APIs for PID providers."""
+
+from __future__ import absolute_import, print_function
 
 from .registry import pidproviders
 

--- a/invenio_pidstore/providers/__init__.py
+++ b/invenio_pidstore/providers/__init__.py
@@ -3,18 +3,23 @@
 # This file is part of Invenio.
 # Copyright (C) 2015 CERN.
 #
-# Invenio is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# Invenio is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Invenio; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 """Module storing implementations of PID providers."""

--- a/invenio_pidstore/providers/datacite.py
+++ b/invenio_pidstore/providers/datacite.py
@@ -1,21 +1,26 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2015 CERN.
 #
-# Invenio is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# Invenio is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Invenio; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 """DataCite PID provider."""
 

--- a/invenio_pidstore/providers/recordid.py
+++ b/invenio_pidstore/providers/recordid.py
@@ -22,20 +22,19 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""Define provider for locally unmanaged DOIs."""
+"""Record ID provider."""
 
-from flask import current_app
+from __future__ import absolute_import, print_function
 
 from ..provider import LocalPidProvider
 
 
-class LocalDOI(LocalPidProvider):
-    """Provider for locally unmanaged DOIs."""
+class RecordID(LocalPidProvider):
+    """Provider for recids."""
 
-    pid_type = 'doi'
+    pid_type = 'recid'
 
     @classmethod
     def is_provider_for_pid(cls, pid_str):
-        """Check if DOI is not the local datacite managed one."""
-        return not pid_str.startswith("{0}/".format(
-            current_app.config['PIDSTORE_DATACITE_DOI_PREFIX']))
+        """Check if RecordID is a provider for ``pid_str``."""
+        return isinstance(pid_str, int) or pid_str.isdigit()

--- a/invenio_pidstore/registry.py
+++ b/invenio_pidstore/registry.py
@@ -1,24 +1,30 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2015 CERN.
 #
-# Invenio is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# Invenio is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Invenio; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 """Registry for PidProviders."""
 
+from __future__ import absolute_import, print_function
 
 from flask import _app_ctx_stack, current_app
 from werkzeug.local import LocalProxy

--- a/invenio_pidstore/resolver.py
+++ b/invenio_pidstore/resolver.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Registry for PidProviders."""
+
+from __future__ import absolute_import, print_function
+
+from .errors import PIDDeletedError, PIDDoesNotExistsError, \
+    PIDMissingObjectError
+from .models import PersistentIdentifier
+
+
+class Resolver(object):
+    """Persistent identifier resolver.
+
+    Helper class for retrieving an internal object for a given persistent
+    identifier.
+    """
+
+    def __init__(self, pid_type=None, pid_provider=None, obj_type=None,
+                 getter=None):
+        """Initialize resovler.
+
+        :param pid_type: Persistent identifier type.
+        :param obj_type: Object type.
+        :param getter: Callable that will take an object id for the given
+            object type and retrieve the internal object.
+        """
+        self.pid_type = pid_type
+        self.pid_provider = pid_provider
+        self.obj_type = obj_type
+        self.object_getter = getter
+
+    def resolve(self, pid_value):
+        """Resolve a persistent identifier to an internal object.
+
+        :param pid_value: Persistent identifier.
+        """
+        pid = PersistentIdentifier.get(self.pid_type, pid_value,
+                                       pid_provider=self.pid_provider)
+        if pid is None:
+            raise PIDDoesNotExistsError(self.pid_type, pid_value)
+        if pid.is_deleted():
+            raise PIDDeletedError(self.pid_type, pid_value)
+
+        obj_id = pid.get_assigned_object(object_type=self.obj_type)
+        if not obj_id:
+            raise PIDMissingObjectError(self.pid_type, pid_value)
+
+        return pid, self.object_getter(obj_id)

--- a/invenio_pidstore/version.py
+++ b/invenio_pidstore/version.py
@@ -28,4 +28,6 @@ This file is imported by ``invenio_pidstore.__init__``,
 and parsed by ``setup.py``.
 """
 
+from __future__ import absolute_import, print_function
+
 __version__ = "1.0.0.dev20151026"

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -22,20 +22,18 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""Define provider for locally unmanaged DOIs."""
 
-from flask import current_app
+"""Module tests."""
 
-from ..provider import LocalPidProvider
+from __future__ import absolute_import, print_function
+
+from invenio_pidstore.providers.recordid import RecordID
 
 
-class LocalDOI(LocalPidProvider):
-    """Provider for locally unmanaged DOIs."""
-
-    pid_type = 'doi'
-
-    @classmethod
-    def is_provider_for_pid(cls, pid_str):
-        """Check if DOI is not the local datacite managed one."""
-        return not pid_str.startswith("{0}/".format(
-            current_app.config['PIDSTORE_DATACITE_DOI_PREFIX']))
+def test_record_provider(app):
+    """Test the class methods of PersistentIdentifier class."""
+    with app.app_context():
+        provider = RecordID()
+        assert provider.is_provider_for_pid(1)
+        assert provider.is_provider_for_pid('1')
+        assert provider.pid_type == 'recid'

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+
+"""Module tests."""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+from invenio_db import db
+
+from invenio_pidstore.errors import PIDDeletedError, PIDDoesNotExistsError, \
+    PIDMissingObjectError
+from invenio_pidstore.models import PersistentIdentifier
+from invenio_pidstore.resolver import Resolver
+
+
+def test_resolver(app):
+    """Test the class methods of PersistentIdentifier class."""
+    with app.app_context():
+        # Live PID
+        pid = PersistentIdentifier.create('recid', '1', 'recid')
+        pid.assign('rec', '1')
+
+        # No object pid.
+        pid = PersistentIdentifier.create('recid', '3', 'recid')
+        pid.register()
+
+        # Deleted PID
+        pid = PersistentIdentifier.create('recid', '2', 'recid')
+        pid.assign('rec', '2')
+        pid.register()
+        db.session.commit()
+        pid.delete()
+        db.session.commit()
+
+        resolver = Resolver(
+            pid_type='recid',
+            pid_provider='recid',
+            obj_type='rec',
+            getter=lambda x: x)
+
+        pid, obj = resolver.resolve('1')
+        assert pid
+        assert obj == '1'
+
+        pytest.raises(PIDDeletedError, resolver.resolve, '2')
+        pytest.raises(PIDMissingObjectError, resolver.resolve, '3')
+        pytest.raises(PIDDoesNotExistsError, resolver.resolve, '4')
+
+        doiresolver = Resolver(
+            pid_type='doi',
+            pid_provider='doi',
+            obj_type='rec',
+            getter=lambda x: x)
+        pytest.raises(PIDDoesNotExistsError, doiresolver.resolve, '1')


### PR DESCRIPTION
* Adds helper class to retrieve an internal object for a given
  persistent identifier.

* Adds temporarily record id provider.

* NOTE PIDStore needs a larger refactoring in order to scale up and
  API is very likely to change.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>