### PR TITLE
tests: temporary isort fix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -35,6 +35,7 @@ charset = utf-8
 indent_size = 4
 # isort plugin configuration
 known_first_party = invenio_pidstore
+known_third_party = invenio_db, datacite
 multi_line_output = 2
 default_section = THIRDPARTY
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -24,7 +24,7 @@
 
 
 pep257 invenio_pidstore && \
-# isort -rc -c -df **/*.py && \
+isort -rc -c -df **/*.py && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
 python setup.py test && \

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -30,7 +30,6 @@ from __future__ import absolute_import, print_function
 from flask import Flask
 from invenio_db import db
 
-
 from invenio_pidstore import InvenioPIDStore
 from invenio_pidstore.models import PersistentIdentifier
 


### PR DESCRIPTION
* Adds datacite and invenio_db as known third parties to .editorconfig

Signed-off-by: Krzysztof Nowak <k.nowak@cern.ch>