### PR TITLE
fetchers: new pid fetchers

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -63,6 +63,13 @@ Minters
    :members:
    :undoc-members:
 
+Fetchers
+--------
+
+.. automodule:: invenio_pidstore.fetchers
+   :members:
+   :undoc-members:
+
 Exceptions
 ----------
 

--- a/invenio_pidstore/__init__.py
+++ b/invenio_pidstore/__init__.py
@@ -40,6 +40,8 @@ PIDStore consists of:
 - `Minters` - small functions that are responsible for minting a specific
   persistent identifier type for a specific internal object type in as
   automatic way as possible.
+- `Fetchers` - small functions that are responsible for returning a minted
+  persistent identifier.
 
 Initialization
 --------------
@@ -302,10 +304,50 @@ You can retrieve registered minters from the extension as well:
 >>> current_pidstore.minters['my_uuid_minter']
 <function my_uuid_minter at ...>
 
+
+Fetchers
+--------
+Fetchers are small functions that are responsible for returning a minted
+persistent identifier.
+
+A fetcher takes two arguments:
+
+- an `object uuid` of the internal object which the persistent identifier
+  should be assigned to.
+- a `dictionary object`, which the fetcher may extract information from. For
+  instance, if a record object is passed, it might contain a previously minted
+  DOI.
+
+Below is an example fetcher which extracts external UUIDs previously minted in
+the dictionary object (which could be e.g. a record):
+
+>>> import uuid
+>>> def my_uuid_fetcher(object_uuid, data):
+...     return data['uuid']
+
+Registering fetchers
+~~~~~~~~~~~~~~~~~~~~
+Fetchers are usually used by other modules and thus registered on the
+Flask application.
+
+First import the proxy to the current application's PIDStore:
+
+>>> from invenio_pidstore import current_pidstore
+
+Next, register a fetcher:
+
+>>> current_pidstore.register_fetcher('my_uuid_fetcher', my_uuid_fetcher)
+
+You can retrieve registered fetchers from the extension as well:
+
+>>> current_pidstore.fetchers['my_uuid_fetcher']
+<function my_uuid_fetcher at ...>
+
+
 Entry points loading
 ~~~~~~~~~~~~~~~~~~~~
-PIDStore will automatically register minters defined by the entry point group
-``invenio_pidstore.minters``.
+PIDStore will automatically register minters and fetchers defined by the entry
+point groups ``invenio_pidstore.minters`` and . ``invenio_pidstore.fetchers``.
 
 Example:
 
@@ -317,6 +359,9 @@ Example:
        entry_points={
            'invenio_pidstore.minters': [
                'recid_minter = invenio_pidstore.minters:recid_minter',
+           ],
+           'invenio_pidstore.fetchers': [
+               'recid_fetcher = invenio_pidstore.fetchers:recid_fetcher',
            ]})
 
 Above is equivalent to:
@@ -324,7 +369,9 @@ Above is equivalent to:
 .. code-block:: python
 
    from invenio_pidstore.minters import recid_minter
+   from invenio_pidstore.fetchers import recid_fetcher
    current_pidstore.register_minter('recid_minter', recid_minter)
+   current_pidstore.register_fetcher('recid_fetcher', recid_fetcher)
 
 """
 

--- a/invenio_pidstore/fetchers.py
+++ b/invenio_pidstore/fetchers.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Persistent identifier minters."""
+
+from __future__ import absolute_import, print_function
+
+from collections import namedtuple
+
+from .providers.recordid import RecordIdProvider
+
+FetchedPID = namedtuple('FetchedPID', ['provider', 'pid_type', 'pid_value'])
+
+
+def recid_fetcher(record_uuid, data):
+    """Fetch a record's identifiers."""
+    return FetchedPID(
+        provider=RecordIdProvider,
+        pid_type=RecordIdProvider.pid_type,
+        pid_value=str(data['control_number']),
+    )

--- a/setup.py
+++ b/setup.py
@@ -149,6 +149,9 @@ setup(
         'invenio_pidstore.minters': [
             'recid_minter = invenio_pidstore.minters:recid_minter',
         ],
+        'invenio_pidstore.fetchers': [
+            'recid_fetcher = invenio_pidstore.fetchers:recid_fetcher',
+        ],
         'invenio_admin.views': [
             'invenio_pidstore_pid = invenio_pidstore.admin:pid_adminview',
         ]

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -45,7 +45,10 @@ def test_init():
     app = Flask('testapp')
     ext = InvenioPIDStore(app)
     assert 'invenio-pidstore' in app.extensions
-    ext.register_minter('testminter', lambda a, b: None)
+    ext.register_minter('testminter',
+                        lambda a, b: 'deadbeef-c0de-c0de-c0de-b100dc0ffee5')
+    ext.register_fetcher('testfetcher',
+                         lambda a, b: 'deadbeef-c0de-c0de-c0de-b100dc0ffee5')
 
     app = Flask('testapp')
     ext = InvenioPIDStore()

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Fetcher tests."""
+
+from __future__ import absolute_import, print_function
+
+import uuid
+
+from invenio_pidstore import current_pidstore
+from invenio_pidstore.fetchers import recid_fetcher
+from invenio_pidstore.minters import recid_minter
+
+
+def test_recid_fetcher(app):
+    """Test base provider."""
+    with app.app_context():
+        rec_uuid = uuid.uuid4()
+        data = {}
+        minted_pid = recid_minter(rec_uuid, data)
+        fetched_pid = recid_fetcher(rec_uuid, data)
+        assert minted_pid.pid_value == fetched_pid.pid_value
+        assert fetched_pid.pid_type == fetched_pid.provider.pid_type
+        assert fetched_pid.pid_type == 'recid'
+
+
+def test_register_fetcher(app):
+    """Test base provider."""
+    with app.app_context():
+        current_pidstore.register_fetcher('anothername', recid_minter)


### PR DESCRIPTION
* NEW Adds pid fetchers which enable to retrieve a PID from a
  previously minted data.

* NEW Adds recid_fetcher which can retrieve pids minted by
  recid_minter.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>