### PR TITLE
admin: object link and uuid filtering

### DIFF
--- a/invenio_pidstore/admin.py
+++ b/invenio_pidstore/admin.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,8 +19,12 @@
 
 """Admin model views for PersistentIdentifier."""
 
+import uuid
+
+from flask import current_app, url_for
 from flask_admin.contrib.sqla import ModelView
 from flask_admin.contrib.sqla.filters import FilterEqual
+from markupsafe import Markup
 
 from .models import PersistentIdentifier, PIDStatus
 
@@ -28,6 +32,26 @@ from .models import PersistentIdentifier, PIDStatus
 def _(x):
     """Identity function for string extraction."""
     return x
+
+
+def object_formatter(v, c, m, p):
+    """Format object view link."""
+    endpoint = current_app.config['PIDSTORE_OBJECT_ENDPOINTS'].get(
+        m.object_type)
+
+    if endpoint and m.object_uuid:
+        return Markup('<a href="{0}">{1}</a>'.format(
+                url_for(endpoint, id=m.object_uuid),
+                _('View')))
+    return ''
+
+
+class FilterUUID(FilterEqual):
+    """UUID aware filter."""
+
+    def apply(self, query, value, alias):
+        """Convert UUID."""
+        return query.filter(self.column == uuid.UUID(value))
 
 
 class PersistentIdentifierModelView(ModelView):
@@ -40,7 +64,7 @@ class PersistentIdentifierModelView(ModelView):
     column_display_all_relations = True
     column_list = (
         'pid_type', 'pid_value', 'status', 'object_type',
-        'object_uuid', 'created', 'updated',
+        'object_uuid', 'created', 'updated', 'object',
     )
     column_labels = dict(
         pid_type=_('PID Type'),
@@ -50,12 +74,15 @@ class PersistentIdentifierModelView(ModelView):
         object_type=_('Object Type'),
         object_uuid=_('Object UUID'),
     )
-    column_filters = ('pid_type', 'pid_value', 'object_type', FilterEqual(
-        PersistentIdentifier.status, 'Status',
-        options=[(s.value, s.title) for s in PIDStatus]
-    ), )
+    column_filters = (
+        'pid_type', 'pid_value', 'object_type',
+        FilterUUID(PersistentIdentifier.object_uuid, _('Object UUID')),
+        FilterEqual(PersistentIdentifier.status, _('Status'),
+                    options=[(s.value, s.title) for s in PIDStatus]),
+    )
     column_searchable_list = ('pid_value', )
     column_default_sort = ('updated', True)
+    column_formatters = dict(object=object_formatter)
     page_size = 25
 
 

--- a/invenio_pidstore/ext.py
+++ b/invenio_pidstore/ext.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -106,6 +106,15 @@ class InvenioPIDStore(object):
         if app.config['PIDSTORE_APP_LOGGER_HANDLERS']:
             for handler in app.logger.handlers:
                 logger.addHandler(handler)
+
+        # Initialize admin object link endpoints.
+        try:
+            pkg_resources.get_distribution('invenio-records')
+            app.config.setdefault('PIDSTORE_OBJECT_ENDPOINTS', dict(
+                rec='recordmetadata.details_view',
+            ))
+        except pkg_resources.DistributionNotFound:
+            app.config.setdefault('PIDSTORE_OBJECT_ENDPOINTS', {})
 
         # Register template filter
         app.jinja_env.filters['pid_exists'] = pid_exists

--- a/invenio_pidstore/models.py
+++ b/invenio_pidstore/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -193,6 +193,18 @@ class PersistentIdentifier(db.Model, Timestamp):
             return cls.query.filter_by(**args).one()
         except NoResultFound:
             raise PIDDoesNotExistError(pid_type, pid_value)
+
+    @classmethod
+    def get_by_object(cls, pid_type, object_type, object_uuid):
+        """Get a persistent identifier for a given object."""
+        try:
+            return cls.query.filter_by(
+                pid_type=pid_type,
+                object_type=object_type,
+                object_uuid=object_uuid
+            ).one()
+        except NoResultFound:
+            raise PIDDoesNotExistError(pid_type, None)
 
     #
     # Assigned object methods

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -27,9 +27,11 @@
 
 from __future__ import absolute_import, print_function
 
+import pkg_resources
 from flask import Flask
 from flask_cli import FlaskCLI
 from invenio_db import db
+from mock import patch
 
 from invenio_pidstore import InvenioPIDStore
 from invenio_pidstore.models import PersistentIdentifier
@@ -66,6 +68,17 @@ def test_logger():
     FlaskCLI(app)
     app.config['PIDSTORE_APP_LOGGER_HANDLERS'] = True
     InvenioPIDStore(app)
+
+
+def test_no_invenio_records():
+    """Test extension initialization."""
+    app = Flask('testapp')
+    FlaskCLI(app)
+    with patch('invenio_pidstore.ext.pkg_resources') as obj:
+        obj.DistributionNotFound = pkg_resources.DistributionNotFound
+        obj.get_distribution.side_effect = pkg_resources.DistributionNotFound
+        InvenioPIDStore(app)
+    assert app.config['PIDSTORE_OBJECT_ENDPOINTS'] == {}
 
 
 def test_template_filters(app):

--- a/tests/test_invenio_pidstore.py
+++ b/tests/test_invenio_pidstore.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -113,6 +113,20 @@ def test_pid_get(app):
             PIDDoesNotExistError,
             PersistentIdentifier.get,
             'doi', doi, pid_provider='cref'
+        )
+
+        # Retrieve by object
+        myuuid = uuid.uuid4()
+        doi = '10.1234/b'
+        PersistentIdentifier.create(
+            'doi', doi, object_type='rec', object_uuid=myuuid)
+        pid = PersistentIdentifier.get_by_object('doi', 'rec', myuuid)
+        assert pid.pid_value == doi
+
+        pytest.raises(
+            PIDDoesNotExistError,
+            PersistentIdentifier.get_by_object,
+            'doi', 'rec', uuid.uuid4()
         )
 
 


### PR DESCRIPTION
* Adds support for filtering PIDs by object uuid.

* Adds support for linking to record (and other) admin views.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>