### PR TITLE
installation: entry point for api app

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -147,6 +147,9 @@ setup(
         'invenio_base.apps': [
             'invenio_pidstore = invenio_pidstore:InvenioPIDStore',
         ],
+        'invenio_base.api_apps': [
+            'invenio_pidstore = invenio_pidstore:InvenioPIDStore',
+        ],
         'invenio_pidstore.minters': [
             'recid_minter = invenio_pidstore.minters:recid_minter',
         ],


### PR DESCRIPTION
* Adds entry point for registering PIDStore with Flask API application.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>

/cc @tiborsimko Needed for Records REST API to work.