### PR TITLE
support changing the status of pids with object type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@
 Changes
 =======
 
+Version 1.2.1 (released 2020-07-22)
+
+- Support returning NEW and RESERVED PIDs by setting the `registered_only` flag.
+- Support setting default status for PIDs with object type and uuid.
+
 Version 1.2.0 (released 2020-03-09)
 
 - Change exception interpolation for better aggregation

--- a/invenio_pidstore/admin.py
+++ b/invenio_pidstore/admin.py
@@ -9,7 +9,6 @@
 """Admin model views for PersistentIdentifier."""
 
 import uuid
-
 from flask import current_app, url_for
 from flask_admin.contrib.sqla import ModelView
 from flask_admin.contrib.sqla.filters import FilterEqual

--- a/invenio_pidstore/fetchers.py
+++ b/invenio_pidstore/fetchers.py
@@ -28,7 +28,6 @@ To see more about providers see :mod:`invenio_pidstore.providers`.
 from __future__ import absolute_import, print_function
 
 from collections import namedtuple
-
 from flask import current_app
 
 from .providers.recordid import RecordIdProvider

--- a/invenio_pidstore/models.py
+++ b/invenio_pidstore/models.py
@@ -490,14 +490,14 @@ class PersistentIdentifier(db.Model, Timestamp):
         return self.status == PIDStatus.DELETED
 
     def is_new(self):
-        """Return true if the PIDhas not yet been registered or reserved.
+        """Return true if the PID is new.
 
         :returns: A boolean value.
         """
         return self.status == PIDStatus.NEW
 
     def is_reserved(self):
-        """Return true if the PID has not yet been reserved.
+        """Return true if the PID has been reserved.
 
         :returns: A boolean value.
         """

--- a/invenio_pidstore/models.py
+++ b/invenio_pidstore/models.py
@@ -10,11 +10,11 @@
 
 from __future__ import absolute_import, print_function
 
-import logging
-import uuid
 from enum import Enum
 
+import logging
 import six
+import uuid
 from flask_babelex import gettext
 from invenio_db import db
 from speaklater import make_lazy_gettext

--- a/invenio_pidstore/providers/recordid_v2.py
+++ b/invenio_pidstore/providers/recordid_v2.py
@@ -38,8 +38,14 @@ class RecordIdProviderV2(BaseProvider):
     provide any additional features besides creation of record ids.
     """
 
-    default_status = PIDStatus.RESERVED
+    default_status_with_obj = PIDStatus.REGISTERED
     """Record IDs are by default registered immediately.
+
+    Default: :attr:`invenio_pidstore.models.PIDStatus.REGISTERED`
+    """
+
+    default_status = PIDStatus.RESERVED
+    """Record IDs with an object are by default reserved.
 
     Default: :attr:`invenio_pidstore.models.PIDStatus.RESERVED`
     """
@@ -91,7 +97,7 @@ class RecordIdProviderV2(BaseProvider):
         kwargs.setdefault('status', cls.default_status)
 
         if object_type and object_uuid:
-            kwargs['status'] = PIDStatus.REGISTERED
+            kwargs['status'] = cls.default_status_with_obj
 
         return super(RecordIdProviderV2, cls).create(
             object_type=object_type, object_uuid=object_uuid, **kwargs)

--- a/invenio_pidstore/providers/recordid_v2.py
+++ b/invenio_pidstore/providers/recordid_v2.py
@@ -12,7 +12,6 @@
 from __future__ import absolute_import
 
 import copy
-
 from base32_lib import base32
 from flask import current_app
 

--- a/invenio_pidstore/resolver.py
+++ b/invenio_pidstore/resolver.py
@@ -24,7 +24,8 @@ class Resolver(object):
     identifier.
     """
 
-    def __init__(self, pid_type=None, object_type=None, getter=None):
+    def __init__(self, pid_type=None, object_type=None, getter=None,
+                 registered_only=True):
         """Initialize resolver.
 
         :param pid_type: Persistent identifier type.
@@ -35,6 +36,7 @@ class Resolver(object):
         self.pid_type = pid_type
         self.object_type = object_type
         self.object_getter = getter
+        self.registered_only = registered_only
 
     def resolve(self, pid_value):
         """Resolve a persistent identifier to an internal object.
@@ -45,7 +47,10 @@ class Resolver(object):
         pid = PersistentIdentifier.get(self.pid_type, pid_value)
 
         if pid.is_new() or pid.is_reserved():
-            raise PIDUnregistered(pid)
+            if self.registered_only:
+                raise PIDUnregistered(pid)
+            else:
+                obj_id = pid.get_assigned_object(object_type=self.object_type)
 
         if pid.is_deleted():
             obj_id = pid.get_assigned_object(object_type=self.object_type)

--- a/invenio_pidstore/version.py
+++ b/invenio_pidstore/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,7 +9,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 pydocstyle invenio_pidstore tests docs && \
-isort -rc -c -df && \
+isort invenio_pidstore tests --check-only --diff && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
 python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -17,20 +17,13 @@ readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
 
 tests_require = [
-    'attrs>=17.4.0',  # once pytest is upgraded this can be removed
-    'SQLAlchemy-Continuum>=1.2.1',
-    'check-manifest>=0.25',
-    'coverage>=4.0',
-    'isort>=4.3.0',
-    'invenio-admin>=1.2.0',
     'Flask-Menu>=0.5.1',
+    'invenio-admin>=1.2.0',
     'invenio-access>=1.0.0',
     'invenio-accounts>=1.0.0',
     'mock>=3.0.0',
-    'pydocstyle>=1.0.0',
-    'pytest-cov>=1.8.0',
-    'pytest-pep8>=1.0.6',
-    'pytest>=3.8.0,<5.0.0',
+    'pytest-invenio<=1.3.2',
+    'SQLAlchemy-Continuum>=1.2.1',
 ]
 
 extras_require = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,10 +11,9 @@
 from __future__ import absolute_import, print_function
 
 import os
+import pytest
 import shutil
 import tempfile
-
-import pytest
 from flask import Flask
 from invenio_db import InvenioDB
 from sqlalchemy_utils.functions import create_database, database_exists

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -10,7 +10,6 @@
 from __future__ import absolute_import, print_function
 
 import uuid
-
 from flask_admin import Admin, menu
 from invenio_db import db
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,6 @@
 from __future__ import absolute_import, print_function
 
 import uuid
-
 from click.testing import CliRunner
 from flask.cli import ScriptInfo
 

--- a/tests/test_invenio_pidstore.py
+++ b/tests/test_invenio_pidstore.py
@@ -11,9 +11,8 @@
 
 from __future__ import absolute_import, print_function
 
-import uuid
-
 import pytest
+import uuid
 from mock import patch
 from sqlalchemy.exc import SQLAlchemyError
 

--- a/tests/test_minters.py
+++ b/tests/test_minters.py
@@ -10,9 +10,8 @@
 
 from __future__ import absolute_import, print_function
 
-import uuid
-
 import pytest
+import uuid
 
 from invenio_pidstore import current_pidstore
 from invenio_pidstore.minters import recid_minter, recid_minter_v2

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -11,9 +11,8 @@
 
 from __future__ import absolute_import, print_function
 
-import uuid
-
 import pytest
+import uuid
 from datacite.errors import DataCiteError, DataCiteGoneError, \
     DataCiteNoContentError, DataCiteNotFoundError, HttpError
 from mock import MagicMock, patch

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -10,9 +10,8 @@
 
 from __future__ import absolute_import, print_function
 
-import uuid
-
 import pytest
+import uuid
 
 from invenio_pidstore.errors import PIDDeletedError, PIDDoesNotExistError, \
     PIDMissingObjectError, PIDRedirectedError, PIDUnregistered


### PR DESCRIPTION
Alternative approach to #131 

It requires to *somewhere* do:

```python
        from invenio_pidstore.models import PIDStatus
        from invenio_pidstore.providers.recordid_v2 import RecordIdProviderV2
        RecordIdProviderV2.default_status_with_obj = PIDStatus.NEW
```

But is much cleaner than all the other `with_obj_type` parameter passing. Plus it is only set once.