### PR TITLE
providers: api consistency

### DIFF
--- a/invenio_pidstore/providers/base.py
+++ b/invenio_pidstore/providers/base.py
@@ -71,7 +71,7 @@ class BaseProvider(object):
                                      pid_provider=cls.pid_provider),
             **kwargs)
 
-    def __init__(self, pid):
+    def __init__(self, pid, **kwargs):
         """Initialize provider using persistent identifier.
 
         :param pid: A :class:`invenio_pidstore.models.PersistentIdentifier`

--- a/invenio_pidstore/providers/datacite.py
+++ b/invenio_pidstore/providers/datacite.py
@@ -50,7 +50,7 @@ class DataCiteProvider(BaseProvider):
         return super(DataCiteProvider, cls).create(
             pid_value=pid_value, **kwargs)
 
-    def __init__(self, pid, client=None):
+    def __init__(self, pid, client=None, **kwargs):
         """Initialize provider.
 
         To use the default client, just configure the following variables:


### PR DESCRIPTION
* The create() method takes kwargs and passes them to __init__, but
  __init__ doesn't take kwargs by default, meaning it's hard to allow
  providers to be exchanged.