### PR TITLE
migrate to flask babel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@
 Changes
 =======
 
+Version 1.3.0 (released 2023-03-02)
+
+- Replace deprecated flask_babelex dependency and imports
+- Upgrade invenio-i18n
+
 Version 1.2.4 (released 2022-11-18)
 
 - Add translations workflow

--- a/invenio_pidstore/__init__.py
+++ b/invenio_pidstore/__init__.py
@@ -368,6 +368,6 @@ from __future__ import absolute_import, print_function
 from .ext import InvenioPIDStore
 from .proxies import current_pidstore
 
-__version__ = "1.2.4"
+__version__ = "1.3.0"
 
 __all__ = ("__version__", "InvenioPIDStore", "current_pidstore")

--- a/invenio_pidstore/models.py
+++ b/invenio_pidstore/models.py
@@ -15,8 +15,8 @@ import uuid
 from enum import Enum
 
 import six
-from flask_babelex import gettext
 from invenio_db import db
+from invenio_i18n import gettext
 from speaklater import make_lazy_gettext
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -22,7 +22,7 @@ trap cleanup EXIT
 
 
 python -m check_manifest
-python -m setup extract_messages --dry-run
+python -m setup extract_messages --output-file /dev/null
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
 eval "$(docker-services-cli up --db ${DB:-postgresql} --cache ${CACHE:-redis} --env)"
 python -m pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,6 @@ tests =
     mock>=3.0.0
     pytest-invenio>=1.4.0
     SQLAlchemy-Continuum>=1.3.11
-    invenio-admin>=1.2.0
     datacite>=0.1.0
     Sphinx>=4.5.0
     invenio-db[mysql,postgresql,versioning]>=1.0.9,<2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,11 +31,11 @@ install_requires =
     importlib_metadata>=4.4
     importlib_resources>=5.0
     invenio-base>=1.2.5
-    invenio-i18n>=1.2.0
+    invenio-i18n>=2.0.0
 
 [options.extras_require]
 tests =
-    pytest-black>=0.3.0,<0.3.10
+    pytest-black>=0.3.0
     Flask-Menu>=0.5.1
     invenio-admin>=1.2.0
     invenio-access>=1.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ import tempfile
 import pytest
 from flask import Flask
 from invenio_db import InvenioDB
+from invenio_i18n import InvenioI18N
 from sqlalchemy_utils.functions import create_database, database_exists
 
 from invenio_pidstore import InvenioPIDStore
@@ -29,6 +30,7 @@ def app(request):
     instance_path = tempfile.mkdtemp()
     app = Flask("testapp", instance_path=instance_path)
     InvenioDB(app)
+    InvenioI18N(app)
     InvenioPIDStore(app)
 
     app.config.update(


### PR DESCRIPTION
- migrate: flask_babelex replaced by invenio_i18n
- fix: --dry-run ignored

- NOTE flask-security-invenio, invenio-accounts, invenio-theme, invenio-i18n have to be released before