### PR TITLE
fix: use invenio-i18n instead of speaklater

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 1.3.1 (released 2023-03-02)
+
+- Remove unnecessary speaklater dependency references
+
 Version 1.3.0 (released 2023-03-02)
 
 - Replace deprecated flask_babelex dependency and imports

--- a/invenio_pidstore/__init__.py
+++ b/invenio_pidstore/__init__.py
@@ -368,6 +368,6 @@ from __future__ import absolute_import, print_function
 from .ext import InvenioPIDStore
 from .proxies import current_pidstore
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 __all__ = ("__version__", "InvenioPIDStore", "current_pidstore")

--- a/invenio_pidstore/models.py
+++ b/invenio_pidstore/models.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -16,8 +17,7 @@ from enum import Enum
 
 import six
 from invenio_db import db
-from invenio_i18n import gettext
-from speaklater import make_lazy_gettext
+from invenio_i18n import lazy_gettext as _
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm.exc import NoResultFound
@@ -30,8 +30,6 @@ from .errors import (
     PIDInvalidAction,
     PIDObjectAlreadyAssigned,
 )
-
-_ = make_lazy_gettext(lambda: gettext)
 
 logger = logging.getLogger("invenio-pidstore")
 


### PR DESCRIPTION
* beside flask-babelex exists also a library called speaklater. this
  library provides functions similar to flask-babelex and flask-babel.
  due to the migration to flask-babel all functionality should be used
  from invenio-i18n.
