### PR TITLE
fix(chore): DeprecationWarning stdlib

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 ..
     This file is part of Invenio.
     Copyright (C) 2015-2020 CERN.
-    Copyright (C) 2024-2025 Graz University of Technology.
+    Copyright (C) 2024-2026 Graz University of Technology.
     Copyright (C) 2025 Northwestern University.
     Copyright (C) 2025 KTH Royal Institute of Technology.
 
@@ -10,6 +10,11 @@
 
 Changes
 =======
+
+Version v3.0.0 (released 2026-01-27)
+
+- chore(setup): bump dependencies
+- fix(chore): DeprecationWarning stdlib
 
 Version v2.2.2 (released 2025-10-21)
 

--- a/invenio_pidstore/__init__.py
+++ b/invenio_pidstore/__init__.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
-# Copyright (C) 2024-2025 Graz University of Technology.
+# Copyright (C) 2024-2026 Graz University of Technology.
 # Copyright (C) 2025 KTH Royal Institute of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
@@ -368,6 +368,6 @@ Above is equivalent to:
 from .ext import InvenioPIDStore
 from .proxies import current_pidstore
 
-__version__ = "2.2.2"
+__version__ = "3.0.0"
 
 __all__ = ("__version__", "InvenioPIDStore", "current_pidstore")

--- a/invenio_pidstore/alembic/734dbec0f3f8_change_datetime_types.py
+++ b/invenio_pidstore/alembic/734dbec0f3f8_change_datetime_types.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2026 Graz University of Technology.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Create pidstore tables."""
+
+from invenio_db.utils import (
+    update_table_columns_column_type_to_datetime,
+    update_table_columns_column_type_to_utc_datetime,
+)
+
+# revision identifiers, used by Alembic.
+revision = "734dbec0f3f8"
+down_revision = "999c62899c20"
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    for table_name in ["pidstore_pid", "pidstore_redirect"]:
+        update_table_columns_column_type_to_utc_datetime(table_name, "created")
+        update_table_columns_column_type_to_utc_datetime(table_name, "updated")
+
+
+def downgrade():
+    """Downgrade database."""
+    for table_name in ["pidstore_pid", "pidstore_redirect"]:
+        update_table_columns_column_type_to_datetime(table_name, "created")
+        update_table_columns_column_type_to_datetime(table_name, "updated")

--- a/invenio_pidstore/models.py
+++ b/invenio_pidstore/models.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
-# Copyright (C) 2023-2024 Graz University of Technology.
+# Copyright (C) 2023-2026 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -21,7 +21,6 @@ from invenio_i18n import lazy_gettext as _
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm.exc import NoResultFound
-from sqlalchemy_utils.models import Timestamp
 from sqlalchemy_utils.types import ChoiceType, UUIDType
 
 from .errors import (
@@ -84,7 +83,7 @@ class PIDStatus(Enum):
         return PID_STATUS_TITLES[self.name]
 
 
-class PersistentIdentifier(db.Model, Timestamp):
+class PersistentIdentifier(db.Model, db.Timestamp):
     """Store and register persistent identifiers.
 
     Assumptions:
@@ -528,7 +527,7 @@ class PersistentIdentifier(db.Model, Timestamp):
         )
 
 
-class Redirect(db.Model, Timestamp):
+class Redirect(db.Model, db.Timestamp):
     """Redirect for a persistent identifier.
 
     You can redirect a PID to another one.

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
-# Copyright (C) 2022-2024 Graz University of Technology.
+# Copyright (C) 2022-2026 Graz University of Technology.
 # Copyright (C) 2024 KTH Royal Institute of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
@@ -36,17 +36,17 @@ install_requires =
 
 [options.extras_require]
 tests =
-    pytest-black-ng>=0.4.0
+    pytest-black>=0.6.0
     Flask-Menu>=2.0.0,<3.0.0
     invenio-admin>=1.2.0,<2.0.0
-    invenio-access>=4.0.0,<5.0.0
-    invenio-accounts>=6.0.0,<7.0.0
+    invenio-access>=5.0.0,<6.0.0
+    invenio-accounts>=7.0.0,<8.0.0
     mock>=3.0.0
-    pytest-invenio>=3.0.0,<4.0.0
+    pytest-invenio>=4.0.0,<5.0.0
     SQLAlchemy-Continuum>=1.3.11
     datacite>=0.1.0
     Sphinx>=4.5.0
-    invenio-db[mysql,postgresql,versioning]>=2.0.0,<3.0.0
+    invenio-db[mysql,postgresql,versioning]>=2.2.0,<3.0.0
 
 [options.entry_points]
 invenio_db.alembic =


### PR DESCRIPTION
* datetime.datetime.utcnow() is deprecated and scheduled for removal in
  a future version. Use timezone-aware objects to represent datetimes in
  UTC: datetime.datetime.now(datetime.UTC).

* the decision was made to move to utc aware timestamps
