### PR TITLE
Remove `importlib-{metadata,resources}`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,8 +8,6 @@ from __future__ import print_function
 
 import sys
 
-import sphinx.environment
-
 from invenio_pidstore import __version__
 
 # Plug example application into module path

--- a/invenio_pidstore/alembic/f615cee99600_create_pidstore_branch.py
+++ b/invenio_pidstore/alembic/f615cee99600_create_pidstore_branch.py
@@ -3,9 +3,6 @@
 
 """Create pidstore branch."""
 
-import sqlalchemy as sa
-from alembic import op
-
 # revision identifiers, used by Alembic.
 revision = "f615cee99600"
 down_revision = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,6 @@ classifiers = [
 ]
 dependencies = [
   "base32-lib>=1.0.1",
-  "importlib_metadata>=4.4",
-  "importlib_resources>=5.0",
   "invenio-base>=2.3.0,<3.0.0",
   "invenio-i18n>=4.0.0,<5.0.0",
 ]


### PR DESCRIPTION
Like https://github.com/inveniosoftware/invenio-base/pull/206

The minimum Python version for this package is 3.9, so we can safely remove these dependencies.